### PR TITLE
Добавляем css явно в список предкомпиляции, т.к. мы используем стили из

### DIFF
--- a/lib/tinymce_insales_skin.rb
+++ b/lib/tinymce_insales_skin.rb
@@ -2,8 +2,8 @@ module TinymceInsalesSkin
   module Rails
     class Engine < ::Rails::Engine
       initializer 'tinymce_insales_skin.assets.precompile' do |app|
-        %w(stylesheets fonts images).each do |sub|
-          app.config.assets.paths << root.join('vendor', 'assets', sub).to_s
+        Dir.glob(root.join('vendor', 'assets', 'stylesheets', "**/*.css").to_s).each do |file|
+          app.config.assets.precompile << file
         end
       end
     end


### PR DESCRIPTION
гема по урлу, а не билдим их в какие то бандлы (tinymce по другому не умеет).
В paths асеты добавлять не надо, т.е. рельсы сами добавляют все подпапки
из vendor/assets